### PR TITLE
Implement basic/feature parity img2img postprocess upscaling

### DIFF
--- a/frontends/krita/krita_diff/client.py
+++ b/frontends/krita/krita_diff/client.py
@@ -278,7 +278,7 @@ class Client(QObject):
             tiling=tiling,
             restore_faces=self.cfg("face_restorer_model", str) != "None",
             override_settings=self.options_params(),
-            override_settings_restore_afterwards=False,
+            override_settings_restore_afterwards=True,
             alwayson_scripts={}
         )
 
@@ -639,6 +639,35 @@ class Client(QObject):
             else {"src_img": img_to_b64(src_img)}
         )
         self.post("upscale", params, cb)
+
+    def post_official_api_upscale_postprocess(self, cb, src_imgs: list, width, height):
+        """Uses official API. Intended for finalizing img2img pipeline."""
+
+        params = dict(
+            resize_mode=1,
+            show_extras_results=False,
+            gfpgan_visibility=0,
+            codeformer_visibility=0,
+            codeformer_weight=0,
+            upscaling_resize=1,
+            upscaling_resize_w=width,
+            upscaling_resize_h=height,
+            upscaling_crop=True,
+            upscaler_1=self.cfg("upscaler_name", str),
+            upscaler_2="None", # Todo: would be nice to support blended upscalers
+            extras_upscaler_2_visibility=0,
+            upscale_first=False,
+            imageList=[]
+        )
+
+        for img in src_imgs:
+            params["imageList"].append({
+                "data": img,
+                "name": "example_image"
+            })
+
+        url = get_url(self.cfg, prefix=OFFICIAL_ROUTE_PREFIX)
+        self.post("extra-batch-images", params, cb, base_url=url)
 
     def post_controlnet_preview(self, cb, src_img):
         unit = self.cfg("controlnet_unit", str)

--- a/frontends/krita/krita_diff/script.py
+++ b/frontends/krita/krita_diff/script.py
@@ -453,12 +453,17 @@ class Script(QObject):
         mask_selection = Selection()
         mask_selection.setPixelData(mask_ba, sx, sy, sw, sh)
 
-        self.doc.setActiveNode(glayer)
-        self.doc.setSelection(mask_selection)
-        self.doc.refreshProjection() # deals with race condition?
-        add_mask_action.trigger()
-        self.doc.waitForDone()
-        self.doc.setSelection(orig_selection)
+        def apply_mask_when_ready():
+            # glayer will be selected when it is done being created
+            if self.doc.activeNode() == glayer: 
+                self.doc.setSelection(mask_selection)
+                add_mask_action.trigger()
+                self.doc.setSelection(orig_selection)
+                timer.stop()
+
+        timer = QTimer()
+        timer.timeout.connect(apply_mask_when_ready)
+        timer.start(0.05)
 
     def apply_controlnet_preview_annotator(self, preview_label): 
         unit = self.cfg("controlnet_unit", str)

--- a/frontends/krita/krita_diff/script.py
+++ b/frontends/krita/krita_diff/script.py
@@ -421,11 +421,16 @@ class Script(QObject):
         add_mask_action = self.app.action("add_new_transparency_mask")
         merge_mask_action = self.app.action("flatten_layer")
 
-        sx = orig_selection.x()
-        sy = orig_selection.y()
-        sw = orig_selection.width()
-        sh = orig_selection.height()
-
+        if orig_selection:
+            sx = orig_selection.x()
+            sy = orig_selection.y()
+            sw = orig_selection.width()
+            sh = orig_selection.height()
+        else:
+            sx = 0
+            sy = 0
+            sw = self.doc.width()
+            sh = self.doc.height()
         # must convert mask to single channel format
         gray_mask = mask_image.convertToFormat(QImage.Format_Grayscale8)
         

--- a/frontends/krita/krita_diff/script.py
+++ b/frontends/krita/krita_diff/script.py
@@ -437,21 +437,22 @@ class Script(QObject):
             sy = 0
             sw = self.doc.width()
             sh = self.doc.height()
+
         # must convert mask to single channel format
         gray_mask = mask_image.convertToFormat(QImage.Format_Grayscale8)
         
-        w = gray_mask.width()
-        h = gray_mask.height()
-        
-        # crop mask to the actual selection side
-        # int division should end up on the right side of rounding here
-        crop_rect = QRect((w - sw)/2,(h - sh)/2, sw, sh)
+        # crop mask to the actual selection size
+        crop_rect = QRect(0, 0, sw, sh)
         crop_mask = gray_mask.copy(crop_rect)
 
         mask_ba = img_to_ba(crop_mask)
 
+        # Why is sizeInBytes() different from width * height? Just... why?
+        w = crop_mask.bytesPerLine() 
+        h = crop_mask.sizeInBytes()/w
+
         mask_selection = Selection()
-        mask_selection.setPixelData(mask_ba, sx, sy, sw, sh)
+        mask_selection.setPixelData(mask_ba, sx, sy, w, h)
 
         def apply_mask_when_ready():
             # glayer will be selected when it is done being created

--- a/frontends/krita/krita_diff/script.py
+++ b/frontends/krita/krita_diff/script.py
@@ -455,7 +455,7 @@ class Script(QObject):
 
         self.doc.setActiveNode(glayer)
         self.doc.setSelection(mask_selection)
-        self.doc.waitForDone() # deals with race condition?
+        self.doc.refreshProjection() # deals with race condition?
         add_mask_action.trigger()
         self.doc.waitForDone()
         self.doc.setSelection(orig_selection)

--- a/frontends/krita/krita_diff/script.py
+++ b/frontends/krita/krita_diff/script.py
@@ -441,8 +441,10 @@ class Script(QObject):
         # must convert mask to single channel format
         gray_mask = mask_image.convertToFormat(QImage.Format_Grayscale8)
         
+        mw = gray_mask.width()
+        mh = gray_mask.height()
         # crop mask to the actual selection size
-        crop_rect = QRect(0, 0, sw, sh)
+        crop_rect = QRect((mw - sw)/2,(mh - sh)/2, sw, sh)
         crop_mask = gray_mask.copy(crop_rect)
 
         mask_ba = img_to_ba(crop_mask)

--- a/frontends/krita/krita_diff/script.py
+++ b/frontends/krita/krita_diff/script.py
@@ -376,8 +376,14 @@ class Script(QObject):
             outputs = response["outputs"] if not controlnet_enabled else response["images"]
 
             if controlnet_enabled: 
-                self.client.post_official_api_upscale_postprocess(
-                    cb_upscale, outputs, self.width, self.height)
+                if min(self.width,self.height) > self.cfg("sd_base_size", int) \
+                    or max(self.width,self.height) > self.cfg("sd_max_size", int):
+                    # this only handles with base/max size enabled
+                    self.client.post_official_api_upscale_postprocess(
+                        cb_upscale, outputs, self.width, self.height)
+                else:
+                    # passing response directly to the callback works fine
+                    cb_upscale(response) 
                 return
 
             layer_name_prefix = "inpaint" if is_inpaint else "img2img"

--- a/frontends/krita/krita_diff/script.py
+++ b/frontends/krita/krita_diff/script.py
@@ -284,6 +284,7 @@ class Script(QObject):
         # freeze selection region
         controlnet_enabled = self.check_controlnet_enabled()
         glayer = self.doc.createGroupLayer("Unnamed Group")
+        self.doc.rootNode().addChildNode(glayer, None)
         insert = self.img_inserter(
             self.x, self.y, self.width, self.height, glayer
         )
@@ -327,8 +328,7 @@ class Script(QObject):
         mask_trigger = self.transparency_mask_inserter()
         mask_image = self.get_mask_image(controlnet_enabled) if is_inpaint else None
         glayer = self.doc.createGroupLayer("Unnamed Group")
-        parent = self.doc.rootNode()
-        parent.addChildNode(glayer, None)
+        self.doc.rootNode().addChildNode(glayer, None)
         insert = self.img_inserter(
             self.x, self.y, self.width, self.height, glayer
         )


### PR DESCRIPTION
Main thing in this is implementation of the same upscaling present in the old API.  Images received from the img2img API will be sent to the `extra-batch-images` endpoint for upscaling.  While this is an extra API call that ideally should not have to happen, it is plenty fast enough.  The results from upscaling are then injected as layers and are masked off properly.

EDIT: Just for reference, I have not tested how this performs in anything but my main workflow of working on obscenely high res images.  Consequently I completely forgot that it might not be desirable to *always* upscale even when the selection is lower res than the generation.  Should still work because the upscaler will happily downscale images when asked to.  I have a couple of other people testing it to hammer out any edge cases.  

Additionally, I fixed two bugs:

`override_settings_restore_afterwards` is now True.  This was causing persistent and unwanted setting changes, like making the webui not return grids in the results.  Everything seems to work just fine with it as True, and it won't attempt to load back the previous model or anything if that's why it was off.

The process for converting the mask has been simplified to three QImage format conversions.  The mask is converted to Alpha8, dropping the RGB channels, and it is reinterpreted as grayscale so that when we convert it back to RGBA8888 it goes to the RGB channels.  Simple, clean, seems to be a bit faster, and doesn't require any specific mask colors, so that limitation can be crossed off the list.